### PR TITLE
fixing unbundling for html bundle include on index.html not being rem…

### DIFF
--- a/dist/unbundle.js
+++ b/dist/unbundle.js
@@ -67,7 +67,7 @@ function removeHtmlImportBundles(config, builder) {
   _Object$keys(config.bundles).forEach(function (key) {
 
     var cfg = config.bundles[key];
-    if (cfg.htmlimports) {
+    if (cfg.htmlimport) {
       tasks.push(_removeHtmlImportBundle(cfg, baseURL, key));
     }
   });
@@ -78,18 +78,19 @@ function removeHtmlImportBundles(config, builder) {
 function _removeHtmlImportBundle(_cfg, _baseURL, bundleName) {
 
   if (!_cfg) _bluebird2['default'].resolve();
+  if (!_cfg.options) _cfg.options = {};
 
-  var inject = cfg.inject;
+  var inject = _cfg.options.inject;
 
   if (!inject) _bluebird2['default'].resolve();
   if (!_lodash2['default'].isObject(inject)) inject = {};
 
-  var cfg = _lodash2['default'].defaults(inject, {
+  var _inject = _lodash2['default'].defaults(inject, {
     indexFile: 'index.html',
     destFile: 'index.html'
   });
 
-  var file = _path2['default'].resolve(_baseURL, cfg.destFile);
+  var file = _path2['default'].resolve(_baseURL, _inject.destFile);
 
   return _bluebird2['default'].promisify(_fs2['default'].readFile)(file, {
     encoding: 'utf8'

--- a/lib/unbundle.js
+++ b/lib/unbundle.js
@@ -42,7 +42,7 @@ function removeHtmlImportBundles(config, builder) {
     .forEach((key) => {
 
       let cfg = config.bundles[key];
-      if(cfg.htmlimports){
+      if(cfg.htmlimport){
          tasks.push(_removeHtmlImportBundle(cfg, baseURL, key))
       }
     });
@@ -53,18 +53,19 @@ function removeHtmlImportBundles(config, builder) {
 function _removeHtmlImportBundle(_cfg, _baseURL, bundleName) {
 
   if(!_cfg) Promise.resolve();
+  if(!_cfg.options) _cfg.options = {};
 
-  let inject = cfg.inject;
+  let inject = _cfg.options.inject;
 
   if(!inject) Promise.resolve();
   if(!_.isObject(inject)) inject = {};
 
-  let cfg = _.defaults(inject, {
+  let _inject = _.defaults(inject, {
     indexFile: 'index.html',
     destFile: 'index.html'
   });
 
-  let file = path.resolve(_baseURL, cfg.destFile);
+  let file = path.resolve(_baseURL, _inject.destFile);
 
   return Promise
     .promisify(fs.readFile)(file, {


### PR DESCRIPTION
Unbundle was not removing link in index.html

"htmlimport" was in the article (http://blog.durandal.io/2015/09/11/bundling-aurelia-apps/) but the code was looking for "htmlimports"

options was replaced with the config and renamed to _cfg, but not everywhere and inject is in _cfg.options base on the article.