### PR TITLE
adding blank options default to prevent bundler failure without options

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -68,7 +68,7 @@ function _bundle(_cfg, name, config) {
   });
 
   var outfile = name + '.js';
-  var opt = cfg.options;
+  var opt = cfg.options || {};
 
   opt.force = config.force;
   opt.packagePath = config.packagePath;

--- a/dist/index.js
+++ b/dist/index.js
@@ -64,11 +64,12 @@ function _bundle(_cfg, name, config) {
 
   var cfg = _lodash2['default'].defaults(_cfg, {
     includes: [],
-    excludes: []
+    excludes: [],
+    options: {}
   });
 
   var outfile = name + '.js';
-  var opt = cfg.options || {};
+  var opt = cfg.options;
 
   opt.force = config.force;
   opt.packagePath = config.packagePath;

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,11 +36,12 @@ function _bundle(_cfg, name, config) {
 
   let cfg = _.defaults(_cfg, {
     includes : [],
-    excludes : []
+    excludes : [],
+    options: {}
   });
 
   let outfile = name + '.js';
-  let opt = cfg.options || {};
+  let opt = cfg.options;
 
   opt.force = config.force;
   opt.packagePath = config.packagePath;

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function _bundle(_cfg, name, config) {
   });
 
   let outfile = name + '.js';
-  let opt = cfg.options;
+  let opt = cfg.options || {};
 
   opt.force = config.force;
   opt.packagePath = config.packagePath;


### PR DESCRIPTION
adding blank options default to prevent bundler failure without options - Fixing https://github.com/aurelia/bundler/issues/13