### PR TITLE
chore(dependencies): update whacko dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "rev-hash": "^1.0.0",
     "rev-path": "^1.0.0",
     "systemjs-builder": "^0.14.6",
-    "whacko": "^0.18.1"
+    "whacko": "^0.19.1"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
I get the following warnings when installing `aurelia-bundler` through npm:

```
npm WARN deprecated CSSselect@0.4.1: the module is now available as 'css-select'
npm WARN deprecated CSSwhat@0.4.7: the module is now available as 'css-what'
npm WARN deprecated lodash@2.4.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^3.0.0.
```

This PR updates the `whacko` dependency, resolving those warnings.

