### PR TITLE
fix to check for current path "." in file list

### DIFF
--- a/lib/html-import-template-bundler.js
+++ b/lib/html-import-template-bundler.js
@@ -28,17 +28,19 @@ export function bundle(cfg) {
       cwd: baseURL.replace(/\\/g, '/')
     })
     .forEach(function(file) {
-      file = path.resolve(baseURL, file);
-      var content = fs.readFileSync(file, {
-        encoding: 'utf8'
-      });
-
-      var $ = whacko.load(content);
-      var name = getCanonicalName(builder, file, 'view').replace(/!view$/g, '');
-
-      $('template').attr('id', name);
-      var template = $.html('template');
-      templates.push(template);
+      if(file != '.') {
+        file = path.resolve(baseURL, file);
+        var content = fs.readFileSync(file, {
+          encoding: 'utf8'
+        });
+  
+        var $ = whacko.load(content);
+        var name = getCanonicalName(builder, file, 'view').replace(/!view$/g, '');
+  
+        $('template').attr('id', name);
+        var template = $.html('template');
+        templates.push(template);
+      }
     });
 
   fs.writeFileSync(outfile, templates.join('\n'));


### PR DESCRIPTION
Fixed the following error when running the bundler with html import enabled.

```
[11:45:10] Starting 'bundle'...
[11:45:11] 'bundle' errored after 1.25 s
[11:45:11] Error: EISDIR, illegal operation on a directory
    at Error (native)
    at Object.fs.readSync (fs.js:552:19)
    at Object.fs.readSync (d:\Project\node_modules\gulp-yu
idoc\node_modules\vinyl-fs\node_modules\graceful-fs\polyfills.js:218:23)
    at Object.fs.readSync (d:\Project\node_modules\gulp-yu
idoc\node_modules\yuidocjs\node_modules\graceful-fs\polyfills.js:218:23)
    at Object.fs.readFileSync (fs.js:389:28)
    at d:\Project\node_modules\aurelia-bundler\dist\html-i
mport-template-bundler.js:62:35
    at Array.forEach (native)
    at Object.bundle (d:\Project\node_modules\aurelia-bund
ler\dist\html-import-template-bundler.js:60:6)
    at _bundleHtmlImportTemplate (d:\Project\node_modules\
aurelia-bundler\dist\index.js:68:15)
    at d:\Project\node_modules\aurelia-bundler\dist\index.
js:54:18
```