### PR TITLE
fix(minify): fix default htmlmin options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,6 @@ export function getHTMLMinOpts(opts) {
     removeCommentsFromCDATA: true,
     removeCDATASectionsFromCDATA: true,
     collapseWhitespace: true,
-    conservativeCollapse: true,
     collapseBooleanAttributes: true,
     removeRedundantAttributes: true,
     useShortDoctype: true,


### PR DESCRIPTION
Right now the bundler minifies html like so:
Input:
```html
<template>
</template>
```
Output (note the space):
```html
<template> </template>
```  

Output with this PR (no space):
```html
<template></template>
```  