### PR TITLE
#143 - Added revisioning to html import template bundler

### DIFF
--- a/lib/html-import-template-bundler.js
+++ b/lib/html-import-template-bundler.js
@@ -24,19 +24,29 @@ export function bundle(cfg) {
         let content = fs.readFileSync(file, {
           encoding: 'utf8'
         });
-  
+
         let $ = whacko.load(content);
         let name = getCanonicalName(builder, file, 'view').replace(/!view$/g, '');
   
         $('template').attr('id', name);
         let template = $.html('template');
+
         templates.push(template);
       }
     });
 
-  let output = templates.join('\n');
-  let outFileName = utils.getOutFileName(output, cfg.bundleName + '.html', cfg.options.rev);
-  let outFilePath = path.resolve(baseURL, outFileName);
+  let outFilePath = writeOutput(cfg.baseURL, cfg.bundleName, templates.join('\n'), cfg.options);
+
+  if (cfg.options && cfg.options.inject) {
+    injectLink(outFilePath, baseURL, cfg.options.inject);
+  }
+
+  return Promise.resolve();
+}
+
+export function writeOutput(pathName, bundleName, output, options) {
+  let outFileName = utils.getOutFileName(output, bundleName + '.html', options && options.rev);
+  let outFilePath = path.resolve(pathName, outFileName);
 
   if (fs.existsSync(outFilePath)) {
     if (!cfg.force) {
@@ -47,11 +57,7 @@ export function bundle(cfg) {
 
   fs.writeFileSync(outFilePath, output);
 
-  if (cfg.options.inject) {
-    injectLink(outFilePath, baseURL, cfg.options.inject);
-  }
-
-  return Promise.resolve();
+  return outFilePath;
 }
 
 

--- a/lib/html-import-template-bundler.js
+++ b/lib/html-import-template-bundler.js
@@ -3,9 +3,9 @@ import whacko from 'whacko';
 import fs from 'fs';
 import path from 'path';
 import globby from 'globby';
-import utils from 'systemjs-builder/lib/utils';
+import sysUtils from 'systemjs-builder/lib/utils';
+import * as utils from './utils';
 import Builder from 'systemjs-builder';
-import _ from 'lodash';
 
 export function bundle(cfg) {
   let builder = new Builder(cfg.baseURL, cfg.configPath);
@@ -13,14 +13,6 @@ export function bundle(cfg) {
 
   let templates = [];
   let baseURL = path.resolve(cfg.baseURL);
-  let outfile = path.resolve(baseURL, cfg.bundleName) + '.html';
-
-  if (fs.existsSync(outfile)) {
-    if (!cfg.force) {
-      throw new Error(`A bundle named '${outfile}' already exists. Use the --force option to overwrite it.`);
-    }
-    fs.unlinkSync(outfile);
-  }
 
   globby
     .sync(cfg.includes, {
@@ -42,10 +34,21 @@ export function bundle(cfg) {
       }
     });
 
-  fs.writeFileSync(outfile, templates.join('\n'));
+  let output = templates.join('\n');
+  let outFileName = utils.getOutFileName(output, cfg.bundleName + '.html', cfg.options.rev);
+  let outFilePath = path.resolve(baseURL, outFileName);
+
+  if (fs.existsSync(outFilePath)) {
+    if (!cfg.force) {
+      throw new Error(`A bundle named '${outFileName}' already exists. Use the --force option to overwrite it.`);
+    }
+    fs.unlinkSync(outFilePath);
+  }
+
+  fs.writeFileSync(outFilePath, output);
 
   if (cfg.options.inject) {
-    injectLink(outfile, baseURL, cfg.options.inject);
+    injectLink(outFilePath, baseURL, cfg.options.inject);
   }
 
   return Promise.resolve();
@@ -85,5 +88,5 @@ function createLink(bundleFile, relpath){
 }
 
 function getCanonicalName(builder, file, pluginName) {
-  return builder.getCanonicalName(utils.toFileURL(file) + '!' + pluginName);
+  return builder.getCanonicalName(sysUtils.toFileURL(file) + '!' + pluginName);
 }

--- a/lib/html-import-template-bundler.js
+++ b/lib/html-import-template-bundler.js
@@ -8,14 +8,34 @@ import * as utils from './utils';
 import Builder from 'systemjs-builder';
 
 export function bundle(cfg) {
+  let baseURL = path.resolve(cfg.baseURL);
   let builder = new Builder(cfg.baseURL, cfg.configPath);
   builder.config(cfg.builderCfg);
 
+  let output = generateOutput(baseURL, cfg.includes, builder);
+  let outputFileName = getOutputFileName(baseURL, cfg.bundleName, output, cfg.options && cfg.options.rev);
+
+  if (fs.existsSync(outputFileName)) {
+    if (!cfg.force) {
+      throw new Error(`A bundle named '${outputFileName}' already exists. Use the --force option to overwrite it.`);
+    }
+    fs.unlinkSync(outputFileName);
+  }
+
+  fs.writeFileSync(outputFileName, output);
+
+  if (cfg.options && cfg.options.inject) {
+    injectLink(outputFileName, baseURL, cfg.options.inject);
+  }
+
+  return Promise.resolve();
+}
+
+export function generateOutput(baseURL, includes, builder) {
   let templates = [];
-  let baseURL = path.resolve(cfg.baseURL);
 
   globby
-    .sync(cfg.includes, {
+    .sync(includes, {
       cwd: baseURL.replace(/\\/g, '/')
     })
     .forEach(function(file) {
@@ -24,42 +44,22 @@ export function bundle(cfg) {
         let content = fs.readFileSync(file, {
           encoding: 'utf8'
         });
-
         let $ = whacko.load(content);
         let name = getCanonicalName(builder, file, 'view').replace(/!view$/g, '');
-  
+
         $('template').attr('id', name);
         let template = $.html('template');
 
         templates.push(template);
       }
     });
-
-  let outFilePath = writeOutput(cfg.baseURL, cfg.bundleName, templates.join('\n'), cfg.options);
-
-  if (cfg.options && cfg.options.inject) {
-    injectLink(outFilePath, baseURL, cfg.options.inject);
-  }
-
-  return Promise.resolve();
+  return templates.join('\n');
 }
 
-export function writeOutput(pathName, bundleName, output, options) {
-  let outFileName = utils.getOutFileName(output, bundleName + '.html', options && options.rev);
-  let outFilePath = path.resolve(pathName, outFileName);
-
-  if (fs.existsSync(outFilePath)) {
-    if (!cfg.force) {
-      throw new Error(`A bundle named '${outFileName}' already exists. Use the --force option to overwrite it.`);
-    }
-    fs.unlinkSync(outFilePath);
-  }
-
-  fs.writeFileSync(outFilePath, output);
-
-  return outFilePath;
+export function getOutputFileName(baseURL, bundleName, output, rev) {
+  let outFileName = utils.getOutFileName(output, bundleName + '.html', rev);
+  return path.resolve(baseURL, outFileName);
 }
-
 
 function injectLink(outfile, baseURL, inject) {
   let bundleFile = path.resolve(baseURL, path.relative(baseURL, outfile));

--- a/test/template-bundle.spec.js
+++ b/test/template-bundle.spec.js
@@ -1,0 +1,40 @@
+import expect from 'expect';
+import revHash from 'rev-hash';
+import {bundle, writeOutput, __RewireAPI__ as bundler} from '../lib/html-import-template-bundler';
+
+let fileBody = '<template>test</template>';
+let fs = {
+  existsSync: path => { },
+  readFileSync: path => fileBody,
+  writeFileSync: (path, string) => { }
+};
+
+bundler.__Rewire__('fs', fs);
+
+describe('A template bundler', () => {
+  /**
+   * Test if the template bundling writes the templates properly into one file
+   */
+  it('writes the bundle to disk', () => {
+    let spy = expect.spyOn(fs, 'writeFileSync');
+    bundle({baseURL: '.', bundleName: 'tmp-bundle', includes: ['tmp1', 'tmp2']});
+    expect(spy.calls.length).toBe(1);
+    expect(spy.calls[0].arguments[1]).toBe('<template id="tmp1">test</template>\n<template id="tmp2">test</template>');
+  });
+
+  /**
+   * Tests if the revisioning works properly and appends a content based hash to the output fileName
+   */
+  it('appends a hash to file name', () => {
+    let baseURL = 'url';
+    let bundleName = 'bundle';
+    let content = 'test\ntest';
+    // Create expected hash and generate urls
+    let expectedHash = revHash(new Buffer(content, 'utf-8'));
+    let revUrl = writeOutput(baseURL, bundleName, content, {rev: true});
+    let revLessUrl = writeOutput(baseURL, bundleName, content, {rev: false});
+
+    expect(revUrl).toContain(expectedHash);
+    expect(revLessUrl).toNotContain(expectedHash);
+  });
+});


### PR DESCRIPTION
Regarding the issue #143 I added the missing revisioning to html import template bundler.
Therefore I changed the code to first generate the bundle, create the fileName, check for an existing bundle and then write the file. This order of tasks is required because the generated hash for the revisioning requires the content.

Adding the `rev: true` to the bundle options will now result in a bundle name like this `view-bundle-cd82b12640`

Example config:
```js
'view-bundle': {
    'htmlimport': true,
    'includes': [
        'app/**/*.html'
    ],
    'options': {
        'rev': true
    }
}
```

Results in:
`view-bundle-cd82b12640.html`